### PR TITLE
chore(realsearch): drop token auth, switch to public search endpoint

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,8 +4,7 @@ GROUP_CHAT_ID="-1003145216234"
 MONGO_DB_URL="mongodb://localhost:27017/afanime"
 TRANSLATOR_BLACK_LIST="Up to 21°C"
 ADMIN_CHAT_IDS="5762880723"
-REAL_SEARCH_URI="https://open-search.acgn.es"
-REAL_SEARCH_TOKEN="jarvis:wqoeqwnbqwdwqeoazpqeqiujklhk"
+REAL_SEARCH_URI="https://search.acgn.es"
 PROXY_ADDRESS="socks://127.0.0.1:7890"
 
 

--- a/docs/src/deployment.md
+++ b/docs/src/deployment.md
@@ -66,13 +66,9 @@ GROUP_CHAT_ID="-1233333" # 用于bot推送的channel id
 MONGO_DB_URL="mongodb://root:12345@mongodb:27017/afanime?authSource=admin" # 本地mongodb连接串
 TRANSLATOR_BLACK_LIST="Up to 21°C" # 字幕组黑名单
 ADMIN_CHAT_IDS="5166880313" # 管理user id，多个用逗号隔开，可用于执行各种管理员命令
-REAL_SEARCH_URI="https://open-search.acgn.es" # RealSearch的公开api endpoint
-REAL_SEARCH_TOKEN="abc:zrKMfVYiwgxNawdawaadawdawdaad" # RealSearch给开发者的个人token
+REAL_SEARCH_URI="https://search.acgn.es" # RealSearch的公开api endpoint
 PROXY_ADDRESS="socks://127.0.0.1:7897" # 如果你的开发/部署环境在中国大陆且代理支持socks，可以通过这里来建立bot实例
 ```
-
-> [!IMPORTANT]
-> RealSearch的public api目前仍在内测，token暂未公开。你或许可以通过联系[作者本人](mailto:quick.joy8246@fastmail.com)索取一个。
 
 然后使用 `pnpm i`安装完依赖之后使用`pnpm run start`启动即可。
 
@@ -119,8 +115,7 @@ environment:
   GROUP_CHAT_ID: '-1233333'
   MONGO_DB_URL: 'mongodb://root:12345@mongodb:27017/afanime?authSource=admin'
   ADMIN_CHAT_IDS: '5166880313'
-  REAL_SEARCH_URI: 'https://open-search.acgn.es'
-  REAL_SEARCH_TOKEN: 'abc:zrKMfVYiwgxNawdawaadawdawdaad'
+  REAL_SEARCH_URI: 'https://search.acgn.es'
   TRANSLATOR_BLACK_LIST: Up to 21°C
   PROXY_ADDRESS: ''
 ```

--- a/src/api/realsearch.ts
+++ b/src/api/realsearch.ts
@@ -5,15 +5,10 @@ import { config } from '#root/config/index.js'
 
 const realSearchAPI = config.realSearchAPI
 
-// const NEP_BASE_URL = realSearchAPI.uri
-const NEP_TOKEN = realSearchAPI.token
 export type possibleResult = TelegramMessageResponse | AxiosError
 export async function useFetchNEP(word: string, page = 0): Promise<possibleResult> {
   return new Promise ((resolve: any, reject: any) => {
-    axios.get(`https://open-search.acgn.es/search/regular`, {
-      headers: {
-        Authorization: `Bearer ${NEP_TOKEN}`,
-      },
+    axios.get(`${realSearchAPI.uri}/api/`, {
       params: {
         cid: 0,
         page,
@@ -32,15 +27,12 @@ export async function useFetchNEP(word: string, page = 0): Promise<possibleResul
 
 export async function useFetchSchedule(): Promise<any> {
   return new Promise ((resolve: any, reject: any) => {
-    axios.get(`https://search.acgn.es/api/public/schedule/v2?rule_id=5`, {
-      headers: {
-        Authorization: `Bearer ${NEP_TOKEN}`,
-      },
-    }).then((response: AxiosResponse<TelegramMessageResponse>) => {
-      const { data } = response
-      resolve(data)
-    }).catch((error: AxiosError) => {
-      reject(error)
-    })
+    axios.get(`${realSearchAPI.uri}/api/public/schedule/v2?rule_id=5`)
+      .then((response: AxiosResponse<TelegramMessageResponse>) => {
+        const { data } = response
+        resolve(data)
+      }).catch((error: AxiosError) => {
+        reject(error)
+      })
   })
 }

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -11,7 +11,6 @@ const values: Config = {
   commandWhiteList: [],
   realSearchAPI: {
     uri: '',
-    token: '',
   },
   proxyAddress: '',
 }
@@ -25,13 +24,12 @@ export interface Config {
   commandWhiteList?: string[]
   realSearchAPI: {
     uri: string
-    token: string
   }
   proxyAddress?: string
 }
 
 function calculateValue() {
-  const requiredEnvKeys = ['BOT_TOKEN', 'GROUP_CHAT_ID', 'MONGO_DB_URL', 'REAL_SEARCH_TOKEN', 'REAL_SEARCH_URI'] as const
+  const requiredEnvKeys = ['BOT_TOKEN', 'GROUP_CHAT_ID', 'MONGO_DB_URL', 'REAL_SEARCH_URI'] as const
 
   // Type-safe environment mapping
   const envMapping = {
@@ -60,15 +58,10 @@ function calculateValue() {
   values.proxyAddress = envs[envMapping.proxyAddress] ?? values.proxyAddress
 
   // Handle realSearchAPI separately for better structure
-  values.realSearchAPI = envs.REAL_SEARCH_TOKEN
-    ? {
-        uri: envs.REAL_SEARCH_URI ?? '',
-        token: envs.REAL_SEARCH_TOKEN,
-      }
-    : {
-        uri: '',
-        token: '',
-      }
+  // Normalize URI by stripping trailing slashes to avoid double slashes when building request URLs
+  values.realSearchAPI = {
+    uri: (envs.REAL_SEARCH_URI ?? '').replace(/\/+$/, ''),
+  }
 
   // Validate required environment variables
   const missingEnvs = requiredEnvKeys.filter(key => !envs[key])

--- a/src/databases/store.ts
+++ b/src/databases/store.ts
@@ -51,7 +51,6 @@ const db: SharedDB = {
   cronInstance: null,
   realSearchAPI: {
     uri: '',
-    token: '',
   },
   proxyAddress: null,
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -100,5 +100,4 @@ export interface IImage {
 
 export interface RealSearchAPI {
   uri: string
-  token: string
 }


### PR DESCRIPTION
RealSearch's public API no longer requires token auth, and the endpoint
moved from open-search.acgn.es to search.acgn.es.

- Remove REAL_SEARCH_TOKEN (config, types, store default, .env.example, deployment docs)
- Update REAL_SEARCH_URI to search.acgn.es; request URLs are now built from this config consistently
- Verified against the live endpoint that requests return data correctly